### PR TITLE
Add new in-game hotkeys "quit to menu" and "quick restart"

### DIFF
--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -43,6 +43,8 @@ bool vid_fullscreen = false;
 
 extern unsigned char *vid_vram;
 extern unsigned int vid_pitch;
+extern void swinitlevel(void);
+extern void swrestart(void);
 
 int keybindings[NUM_KEYS] = {
 	0,                    // KEY_UNKNOWN
@@ -573,6 +575,10 @@ static void getevents(void)
 						"user aborted with 3 ^C's\n");
 					exit(-1);
 				}
+			} else if (ctrldown && event.key.keysym.sym == SDLK_r) {
+					swinitlevel();
+			} else if (ctrldown && event.key.keysym.sym == SDLK_q) {
+					swrestart();
 			} else if (event.key.keysym.sym == SDLK_RETURN) {
 				if (altdown) {
 					vid_fullscreen = !vid_fullscreen;

--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -47,6 +47,7 @@ extern void swinitlevel(void);
 extern void swrestart(void);
 extern int gamenum;
 extern int getStartingLevel(void);
+extern bool isNetworkGame(void);
 
 int keybindings[NUM_KEYS] = {
 	0,                    // KEY_UNKNOWN
@@ -577,10 +578,10 @@ static void getevents(void)
 						"user aborted with 3 ^C's\n");
 					exit(-1);
 				}
-			} else if (ctrldown && event.key.keysym.sym == SDLK_r) {
+			} else if (ctrldown && event.key.keysym.sym == SDLK_r && !isNetworkGame()) {
 					gamenum = getStartingLevel();
 					swinitlevel();
-			} else if (ctrldown && event.key.keysym.sym == SDLK_q) {
+			} else if (ctrldown && event.key.keysym.sym == SDLK_q && !isNetworkGame()) {
 					swrestart();
 			} else if (event.key.keysym.sym == SDLK_RETURN) {
 				if (altdown) {

--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -45,6 +45,8 @@ extern unsigned char *vid_vram;
 extern unsigned int vid_pitch;
 extern void swinitlevel(void);
 extern void swrestart(void);
+extern int gamenum;
+extern int getStartingLevel(void);
 
 int keybindings[NUM_KEYS] = {
 	0,                    // KEY_UNKNOWN
@@ -576,6 +578,7 @@ static void getevents(void)
 					exit(-1);
 				}
 			} else if (ctrldown && event.key.keysym.sym == SDLK_r) {
+					gamenum = getStartingLevel();
 					swinitlevel();
 			} else if (ctrldown && event.key.keysym.sym == SDLK_q) {
 					swrestart();

--- a/src/swinit.c
+++ b/src/swinit.c
@@ -1111,7 +1111,8 @@ void swinit(int argc, char *argv[])
 		PLAYMODE_UNSET;
 }
 
-int getStartingLevel(){
+int getStartingLevel(void)
+{
 	return starting_level;
 }
 

--- a/src/swinit.c
+++ b/src/swinit.c
@@ -1111,6 +1111,10 @@ void swinit(int argc, char *argv[])
 		PLAYMODE_UNSET;
 }
 
+int getStartingLevel(){
+	return starting_level;
+}
+
 //
 // 2003-02-14: Code was checked into version control; no further entries
 // will be added to this log.

--- a/src/tcpcomm.c
+++ b/src/tcpcomm.c
@@ -288,3 +288,14 @@ void commterm(void)
 	}
 #endif      /* #ifdef TCPIP */
 }
+
+bool isNetworkGame(void)
+{
+#ifdef TCPIP
+	if (tcp_sock > 0) {
+		return true;
+	}
+#endif   /* #ifdef TCPIP */
+
+	return false;
+}


### PR DESCRIPTION
### Summary
This is a new feature that adds two hotkeys during single player gameplay. When a network game is active, the two hotkeys are disabled.

### Quit to Menu
Pressing ctrl+q quits back to the menu. This differs from the existing ctrl+break hotkey, which instead crashes the player's plane, and then exits the program completely.

### Quick Restart
Pressing ctrl+r instantly restarts the game in the current mode, at the starting level. If a starting level was specified as a command-line option using `-g#`, that level is used.