### PR TITLE
Add new feature: selectable video palettes

### DIFF
--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -30,14 +30,28 @@
 
 //#define LCD
 
-static SDL_Color cga_pal[] = {
-#ifdef LCD
-	{213, 226, 138}, {150, 160, 150},
-	{120, 120, 160}, {0, 20, 200},
-#else
-	{0, 0, 0}, {0, 255, 255},
-	{255, 0, 255}, {255, 255, 255},
-#endif
+static SDL_Color cga_pal[] = {{}, {}, {}, {}};
+
+typedef struct {
+	char name[13]; // Up to 12 characters will display correctly on the menu
+	SDL_Color color[4];
+} VideoPalette;
+
+VideoPalette VideoPalettes[] = {
+	{"CGA 1", 		// CGA black, cyan, magenta, white (Sopwith's default color scheme)
+		{{0, 0, 0}, {0, 255, 255}, {255, 0, 255}, {255, 255, 255}}},
+	{"CGA 2", 		// CGA black, red, green, yellow
+		{{0, 0, 0}, {0, 255, 0}, {255, 0, 0}, {255, 255, 0}}},
+	{"CGA Amber",   // Shades of amber from a monochrome CGA display
+		{{0, 0, 0}, {242, 125, 0}, {255, 170, 16}, {255, 226, 52}}},
+	{"CGA Green", 	// Shades of green from a monochrome CGA display
+		{{0, 0, 0}, {8, 202, 48}, {12, 238, 56}, {49, 253, 90}}},
+	{"CGA Grey", 	// Shades of grey from a monochrome CGA display
+		{{0, 0, 0}, {182, 186, 182}, {222, 222, 210}, {255, 255, 255}}},
+	{"LCD 1",		// Toshiba laptop with STN panel
+		{{213, 226, 138}, {150, 160, 150}, {120, 120, 160}, {0, 20, 200}}},
+	{"LCD 2",		// Toshiba laptop with STN panel, reversed
+		{{0, 20, 200}, {120, 120, 160}, {150, 160, 150}, {213, 226, 138}}},
 };
 
 bool vid_fullscreen = false;
@@ -494,6 +508,27 @@ void Vid_Reset(void)
 	// need to redraw buffer to screen
 
 	Vid_Update();
+}
+
+void Vid_SetVideoPalette(int palette)
+{
+	cga_pal[0] = VideoPalettes[palette].color[0];
+	cga_pal[1] = VideoPalettes[palette].color[1];
+	cga_pal[2] = VideoPalettes[palette].color[2];
+	cga_pal[3] = VideoPalettes[palette].color[3];
+	SDL_SetPaletteColors(screenbuf->format->palette, cga_pal, 0, sizeof(cga_pal) / sizeof(*cga_pal));
+	Vid_Update();
+}
+
+const char* Vid_GetVideoPaletteName(int palette)
+{
+        return VideoPalettes[palette].name;
+}
+
+int Vid_GetNumVideoPalettes(void)
+{
+    int numPalettes = sizeof(VideoPalettes) / sizeof(VideoPalettes[0]);
+	return numPalettes;
 }
 
 #define INPUT_BUFFER_LEN 32

--- a/src/swinit.c
+++ b/src/swinit.c
@@ -1093,6 +1093,7 @@ void swinit(int argc, char *argv[])
 
 	Timer_Init();
 	Vid_Init();
+	Vid_SetVideoPalette(conf_video_palette);
 
 	// dont init speaker if started with -q (quiet)
 	if (soundflg) {

--- a/src/swmain.c
+++ b/src/swmain.c
@@ -37,6 +37,8 @@ bool conf_harrykeys = 0;            // plane rotation relative to screen
 bool conf_medals = 1;
 bool conf_big_explosions = 1;       // big oil tank explosions
 
+int conf_video_palette = 0;			// Video palette selection (0 is the default CGA color scheme)
+
 playmode_t playmode;		/* Mode of play                     */
 const GAMES *currgame;		/* Game parameters and current game */
 OBJECTS *consoleplayer;

--- a/src/swmain.h
+++ b/src/swmain.h
@@ -30,6 +30,7 @@ extern bool conf_animals;
 extern bool conf_harrykeys;
 extern bool conf_medals;
 extern bool conf_big_explosions;
+extern int conf_video_palette;
 
 extern OBJECTS *consoleplayer;
 extern playmode_t playmode;

--- a/src/video.h
+++ b/src/video.h
@@ -61,6 +61,12 @@ extern void Vid_Update(void);
 
 extern bool Vid_GetCtrlBreak(void);
 
+// video palette
+
+void Vid_SetVideoPalette(int palette);
+const char* Vid_GetVideoPaletteName(int palette);
+int Vid_GetNumVideoPalettes(void);
+
 // keyboard functions
 
 extern int Vid_GetKey(void);


### PR DESCRIPTION
## Summary
This new feature adds a selectable video palette to the options menu. Pressing `2` on the menu cycles through the available color palettes. The player's choice is saved and reloaded between sessions.

Addresses issue #29.

## Implementation

1. Added new struct `VideoPalette` to hold the name and color values of each palette:
    ```c
	{"CGA 1", // CGA black, cyan, magenta, white (Sopwith's default color scheme)
		{{0, 0, 0}, {0, 255, 255}, {255, 0, 255}, {255, 255, 255}}},
	{"CGA 2", // CGA black, red, green, yellow
		{{0, 0, 0}, {0, 255, 0}, {255, 0, 0}, {255, 255, 0}}},
	{"CGA Amber", // Shades of amber from a monochrome CGA display
		{{0, 0, 0}, {242, 125, 0}, {255, 170, 16}, {255, 226, 52}}},
	{"CGA Green", // Shades of green from a monochrome CGA display
		{{0, 0, 0}, {8, 202, 48}, {12, 238, 56}, {49, 253, 90}}},
	{"CGA Grey", // Shades of grey from a monochrome CGA display
		{{0, 0, 0}, {182, 186, 182}, {222, 222, 210}, {255, 255, 255}}},
	{"LCD 1", // Toshiba laptop with STN panel
		{{213, 226, 138}, {150, 160, 150}, {120, 120, 160}, {0, 20, 200}}},
	{"LCD 2", // Toshiba laptop with STN panel, reversed
		{{0, 20, 200}, {120, 120, 160}, {150, 160, 150}, {213, 226, 138}}},
    ```
3. Options now support a new `CONF_INT` type, of which `conf_video_palette` is the first.
4. Three new functions:
    1. `Vid_SetVideoPalette()` sets the video palette to a specified entry from the list of palettes
    2. `Vid_GetVideoPaletteName()` returns the name of a given video palette, for use on the options menu
    3. `Vid_GetNumVideoPalettes()` counts how many video palettes have been defined

When the options menu is active, there are points at which it must know whether it's dealing with a `CONF_BOOL`, `CONF_INT`, or `CONF_KEY`. In the case of `CONF_INT`, since the video palettes have names, there is a further check based on the name of the current option being considered.

## Testing
I focused on making sure that the game defaults to the original video palette, if `sopwith.cfg` :
- Does not contain an entry for `conf_video_palette`
- Has an invalid character or out of range number for `conf_video_palette`

Entering the options menu with an invalid setting causes no unwanted behavior.

## Video Palettes

Below are the first wave of new video palettes for SDL Sopwith.

To determine some of their color values, I used [86box](https://86box.net/) to emulate PC hardware with a CGA video card installed, hooked up to a variety of displays. I took screenshots and used Photoshop to get the numbers.

<img src="https://github.com/fragglet/sdl-sopwith/assets/104890/a0bbf683-21b3-4e27-ad10-74634ee35449" width="75%">

In issue #29, @fragglet suggested:
> * Let's make sure there's enough contrast to see things properly - the amber scheme in your screenshot makes it look like the two darker shades are hard to distinguish

The amber palette is now taken from 86box (and looks great!), but it's worth mentioning that both the grey and green palettes _are_ somewhat hard to distinguish, even though they're "accurate". 

I think it's fair to adjust the colors for fun and useability, but I as I was working I kept thinking about accuracy and how nice it would be to have a full CRT shader with scanlines. 😅

### CGA 1
![CGA-1-Title](https://github.com/fragglet/sdl-sopwith/assets/104890/698f8273-6d7e-4d83-8f9d-054acdddc3fe)
![CGA-1-Options](https://github.com/fragglet/sdl-sopwith/assets/104890/7bcb42f1-ceeb-4620-9d58-da74ec6a2872)

### CGA 2
![CGA-2-Title](https://github.com/fragglet/sdl-sopwith/assets/104890/faa676f1-54ac-4c70-b649-895eddd0c0df)
![CGA-2-Options](https://github.com/fragglet/sdl-sopwith/assets/104890/9f3e8945-d6fd-4a68-885e-1ea9c678c739)

### CGA Amber
![CGA-Amber-Title](https://github.com/fragglet/sdl-sopwith/assets/104890/7b65e94f-83d1-45c1-84de-8ded8ddd8475)
![CGA-Amber-Options](https://github.com/fragglet/sdl-sopwith/assets/104890/bce28bbf-52a2-481f-aedb-115e305d8688)

### CGA Green
![CGA-Green-Title](https://github.com/fragglet/sdl-sopwith/assets/104890/7a9309bd-6a87-47ab-b541-d93bda89d3c6)
![CGA-Green-Options](https://github.com/fragglet/sdl-sopwith/assets/104890/4941fa72-c644-4478-b783-9ea1ee302285)

### CGA Grey
![CGA-Grey-Title](https://github.com/fragglet/sdl-sopwith/assets/104890/11091bfa-1042-413a-ae05-a63574925c68)
![CGA-Grey-Options](https://github.com/fragglet/sdl-sopwith/assets/104890/37fd30bf-78a8-4bd5-bce0-56467f15ae2c)

### LCD 1
![LCD-1-Title](https://github.com/fragglet/sdl-sopwith/assets/104890/56bdced4-ec8e-4254-85bc-1dbda82ce849)
![LCD-1-Options](https://github.com/fragglet/sdl-sopwith/assets/104890/50108950-6354-48ec-aaa7-eedec42193fd)

### LCD 2
![LCD-2-Title](https://github.com/fragglet/sdl-sopwith/assets/104890/beb18a0f-555f-4c46-a035-78510314107c)
![LCD-2-Options](https://github.com/fragglet/sdl-sopwith/assets/104890/217a0030-4cf8-4a63-850e-5e3d1cf01799)
