### PR TITLE
Add support for Numeric Keypad Enter

### DIFF
--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -597,7 +597,7 @@ static void getevents(void)
 	while (SDL_PollEvent(&event)) {
 		switch (event.type) {
 		case SDL_KEYDOWN:
-			if (event.key.keysym.sym == SDLK_LALT) {
+			if (event.key.keysym.sym == SDLK_LALT || event.key.keysym.sym == SDLK_RALT) {
 				altdown = 1;
 			} else if (event.key.keysym.sym == SDLK_LCTRL
 			        || event.key.keysym.sym == SDLK_RCTRL) {
@@ -616,12 +616,17 @@ static void getevents(void)
 					swinitlevel();
 			} else if (ctrldown && event.key.keysym.sym == SDLK_q && !isNetworkGame()) {
 					swrestart();
-			} else if (event.key.keysym.sym == SDLK_RETURN) {
-				if (altdown) {
+			} else if (altdown && (event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER)) {
 					vid_fullscreen = !vid_fullscreen;
 					Vid_Reset();
+					altdown = 0;
 					continue;
-				}
+			} else if (!altdown && event.key.keysym.sym == SDLK_KP_ENTER && SDL_IsTextInputActive()) {
+					SDL_Keysym fake;
+					fake.sym = '\n';
+					fake.scancode = SDL_SCANCODE_UNKNOWN;
+					input_buffer_push(fake);
+					continue;
 			}
 			if (!SDL_IsTextInputActive()
 			 || IsSpecialKey(&event.key.keysym)) {
@@ -635,7 +640,7 @@ static void getevents(void)
 			break;
 
 		case SDL_KEYUP:
-			if (event.key.keysym.sym == SDLK_LALT) {
+			if (event.key.keysym.sym == SDLK_LALT || event.key.keysym.sym == SDLK_RALT) {
 				altdown = 0;
 			} else if (event.key.keysym.sym == SDLK_LCTRL
 			        || event.key.keysym.sym == SDLK_RCTRL) {


### PR DESCRIPTION
## Summary

Changes keyboard handling in these ways:

1. Alt+Enter using Right Alt now toggles fullscreen mode (previously only Left Alt worked)
2. Alt+Enter using Numeric Keypad Enter now toggles fullscreen mode (previously only Enter worked)
3. Numeric Keypad Enter now functions the same as Enter when inputting text
4. `altdown` is explicitly set to 0 when fulscreen mode is toggled

## Details

I was getting frustrated with entering an IP address for network connections using the numeric keypad, only to find that Numeric Keypad Enter didn't work. 😅

SDL appears to be handling `SDLK_KP_ENTER` differently than `SDLK_RETURN` when text input is active? Although I was easily able to add Numeric Keypad Enter when checking for Alt+Enter, I had to explicitly push `\n` into the input buffer when the key is pressed during text input.

Although I don't regularly press Alt+Enter using Numeric Keypad Enter myself, I decided to support it after verifying that it's customary in other games. (Downwell, RimWorld, Tony Hawk's Pro Skater 1+2)

Finally, I ran into a curious issue in my WSL development environment:

Normally, when you toggle fullscreen mode in SDL Sopwith on Windows or MacOS, Alt is considered no longer pressed even if you're still holding it. Meaning that if you want to want to toggle fullscreen mode a second time, you must first let go of Alt, and then press Alt+Enter again. (Which is totally fine.)

But, under WSL, that doesn't seem to happen naturally, and in fact the `SDL_KEYUP` for Alt doesn't always appear to be caught. So I've added an `altdown = 0` line that explicitly forces the normal behavior:

```c
} else if (altdown && (event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER)) {
		vid_fullscreen = !vid_fullscreen;
		Vid_Reset();
		altdown = 0;
		continue;
```

By adding this, my WSL build behaves as it should, and does not cause any changes in behavior for Windows and MacOS.

## Testing

I verified that the keys I worked on still behave as expected elsewhere, such as the key bindings menu.