### PR TITLE
Add CGA "mode 5"-style video palette

### DIFF
--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -42,6 +42,8 @@ VideoPalette VideoPalettes[] = {
 		{{0, 0, 0}, {0, 255, 255}, {255, 0, 255}, {255, 255, 255}}},
 	{"CGA 2", 		// CGA black, red, green, yellow
 		{{0, 0, 0}, {0, 255, 0}, {255, 0, 0}, {255, 255, 0}}},
+	{"CGA 3", 		// CGA black, cyan, red, white (aka CGA mode 5)
+		{{0, 0, 0}, {0, 255, 255}, {255, 0, 0}, {255, 255, 255}}},
 	{"Mono Amber",   // Shades of amber from a monochrome CGA display
 		{{0, 0, 0}, {255, 170, 16}, {242, 125, 0}, {255, 226, 52}}},
 	{"Mono Green", 	// Shades of green from a monochrome CGA display


### PR DESCRIPTION
### Summary

Suggested by PickledDog, the new CGA 3 video palette replicates the color scheme of [Mode 5](https://en.wikipedia.org/wiki/Color_Graphics_Adapter#Standard_graphics_modes), which replaces the magenta in Palette 1 with the red of Palette 0. It wasn't used in many games, but a few standouts like [Life & Death](https://en.wikipedia.org/wiki/Life_%26_Death) made great use of it.

### CGA 3
![CGA 3 title](https://github.com/fragglet/sdl-sopwith/assets/104890/8a78f982-f592-4908-a840-8f9ead3a9dfd)
![CGA 3 options](https://github.com/fragglet/sdl-sopwith/assets/104890/6e678b8f-d589-445b-9f86-d86c9469fbab)
![CGA 3 gameplay](https://github.com/fragglet/sdl-sopwith/assets/104890/f2d69792-4864-4fa1-94f2-59f93a8aaa6d)
