### PR TITLE
Change the aspect ratio to 4:3.

### DIFF
--- a/src/sdl/video.c
+++ b/src/sdl/video.c
@@ -429,7 +429,7 @@ static void Vid_SetMode(void)
 	// Important: Set the "logical size" of the rendering context. At the
 	// same time this also defines the aspect ratio that is preserved while
 	// scaling and stretching the texture into the window.
-	SDL_RenderSetLogicalSize(renderer, SCR_WDTH, SCR_HGHT);
+	SDL_RenderSetLogicalSize(renderer, SCR_WDTH, SCR_WDTH * 3 / 4);
 
 	// Blank out the full screen area in case there is any junk in
 	// the borders that won't otherwise be overwritten.


### PR DESCRIPTION
Technically speaking, this also impacts SDL mouse and touch events, but SDL Sopwith does not currently check these.
Hopefully, this one-liner change should be sufficient, at least before the game's 40th anniversary.

No toggle has been added for now, given familiarity with the preference to have a relatively limited set of settings for SDL Sopwith's menus and Chocolate Doom's setup program.