### PR TITLE
Re-order CFLAGS to ensure local headers found first

### DIFF
--- a/src/sdl/Makefile.am
+++ b/src/sdl/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS=@CFLAGS@ @SDL_CFLAGS@ -I$(srcdir)/..
+AM_CFLAGS=-I$(srcdir)/.. @CFLAGS@ @SDL_CFLAGS@
 
 noinst_LIBRARIES = libsdlsopwith.a libsdlsopmain.a
 


### PR DESCRIPTION
Includes from sdl sources may get headers from host paths added via build environment or @SDL_CFLAGS@, if there is a name collision (possible with "sw.h").