### PR TITLE
Remove sudo commands from install instructions

### DIFF
--- a/getit.md
+++ b/getit.md
@@ -23,15 +23,14 @@ getting SDL Sopwith into as many different package repositories as
 possible. If you don't see your favorite operating system in this list,
 [help us fix that!](https://docs.google.com/spreadsheets/d/1vHihJR5VAL9ltEB10kdl_ofK7LViOhwYC0i6T2mqB64/edit).
 
-| Alpine Linux  | `sudo apk add sopwith`       |
+| Alpine Linux  | `apk add sopwith`            |
 | Arch Linux    | `yay -S sopwith`             |
 | ALT Linux     | `apt-get install sopwith`    |
-| Debian        | `sudo apt install sopwith`   |
+| Debian        | `apt install sopwith`        |
 | Fedora        | `dnf install sopwith`        |
 | Flatpak       | `flatpak install flathub io.github.fragglet.sdl_sopwith` |
 | FreeBSD       | `pkg install sopwith`        |
 | OpenBSD       | `pkg_add sdl-sopwith`        |
 | OpenSuSE      | `zypper install sopwith`     |
-| Ubuntu        | `sudo apt install sopwith`   |
-| Void Linux    | `sudo xbps-install sopwith`  |
-
+| Ubuntu        | `apt install sopwith`        |
+| Void Linux    | `xbps-install sopwith`       |


### PR DESCRIPTION
Pretty much all of the install commands are meant to be run with root permissions so it seems inconsistent that only some of them to specify the need to run with root perms (sudo) while others leave it out, so I removed the "sudo" from the commands that have it. 

Alternatively, "sudo" could be added to the other commands too but I feel that's a worse option since not every OS/distro has sudo preinstalled, and sudo isn't the only way to get root privileges.